### PR TITLE
Update bootstrap-switch.less

### DIFF
--- a/static/less/bootstrap-switch.less
+++ b/static/less/bootstrap-switch.less
@@ -26,6 +26,7 @@
   overflow: hidden;
   line-height: 8px;
   .user-select(none);
+  vertical-align: middle;
 
   min-width: 100px;
 


### PR DESCRIPTION
fix switch btn align bug for firefox, ie
